### PR TITLE
Adjusted UVL parser to support less restrictive feature names

### DIFF
--- a/resources/uvl.bnf
+++ b/resources/uvl.bnf
@@ -38,7 +38,7 @@ Reference = REF
 
 indent = '_INDENT_'
 dedent = '_DEDENT_'
-<strictID> = nonWhiteSpaces | whiteSpaces
+<strictID> = noWhiteSpaces | whiteSpaces
 <noWhiteSpaces> = #'(?!alternative|or|features|constraints|true|false|as|refer)[a-zA-Z][a-zA-Z_0-9\+]*'
 <whiteSpaces> = #'\"(?!alternative|or|features|constraints|true|false|as|refer)[a-zA-Z][a-zA-Z_0-9\+\ ]*\"'
 <ID> = #'(?!true|false)[a-zA-Z][a-zA-Z_0-9]*'

--- a/resources/uvl.bnf
+++ b/resources/uvl.bnf
@@ -38,7 +38,9 @@ Reference = REF
 
 indent = '_INDENT_'
 dedent = '_DEDENT_'
-<strictID> = #'(?!alternative|or|features|constraints|true|false|as|refer)[a-zA-Z][a-zA-Z_0-9]*'
+<strictID> = nonWhiteSpaces | whiteSpaces
+<noWhiteSpaces> = #'(?!alternative|or|features|constraints|true|false|as|refer)[a-zA-Z][a-zA-Z_0-9\+]*'
+<whiteSpaces> = #'\"(?!alternative|or|features|constraints|true|false|as|refer)[a-zA-Z][a-zA-Z_0-9\+\ ]*\"'
 <ID> = #'(?!true|false)[a-zA-Z][a-zA-Z_0-9]*'
 REF = (ID <'.'>)* strictID
 <int> = #'0|[1-9]\d*'

--- a/resources/uvl.bnf
+++ b/resources/uvl.bnf
@@ -1,8 +1,8 @@
 FeatureModel = Ns? Imports? Features? Constraints?
 
-Ns = <'namespace'> REF
+Ns = <'namespace'> REF-Restrictive
 Imports = <'imports'> (<indent> Import+ <dedent>)?
-Import = REF (<'as'> As)?
+Import = REF-Restrictive (<'as'> As)?
 As = ID
 
 Features = <'features'> Children?
@@ -38,7 +38,11 @@ Reference = REF
 
 indent = '_INDENT_'
 dedent = '_DEDENT_'
-<strictID> = #'(?!alternative|or|features|constraints|true|false|as|refer)[a-zA-Z][a-zA-Z_0-9]*'
+<strictID> = strictIDdef | <'"'> strictIDdefQ <'"'>
+<strictIDdef> = #'(?!alternative|or|features|constraints|true|false|as|refer|_INDENT_|_DEDENT_)[^\s\"\.\{\}\[\]\(\)\=\>\<\|\&\!]+'
+<strictIDdefQ> = #'[^\"\.\n\r]+'
 <ID> = #'(?!true|false)[a-zA-Z][a-zA-Z_0-9]*'
 REF = (ID <'.'>)* strictID
+<strictID-Restrictive> = #'(?!alternative|or|features|constraints|true|false|as|refer)[a-zA-Z][a-zA-Z_0-9]*'
+REF-Restrictive = (ID <'.'>)* strictID-Restrictive
 <int> = #'0|[1-9]\d*'

--- a/src/de/neominik/uvl/transform.clj
+++ b/src/de/neominik/uvl/transform.clj
@@ -80,6 +80,7 @@
 
 (def transform-map {:FeatureModel xf-featuremodel
                     :REF xf-ref
+                    :REF-Restrictive xf-ref
                     :Imports xf-imports
                     :Import xf-import
 


### PR DESCRIPTION
Fixed UVL parser for https://github.com/FeatureIDE/FeatureIDE/issues/1143

Feature names may now include any character, except " (quotes) and . (dots).
If a feature name contains white spaces, the feature name is surrounded by quotes.
When a UVL model file is parsed, quotes are removed. When a UVL model is printed to a file, quotes are pre- and appended when needed.

https://github.com/technomancy/leiningen has been used to compile the clojure code.