### PR TITLE
Add POM for automated Maven build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 # Edit at https://www.gitignore.io/?templates=vim,clojure
 
 ### Clojure ###
-pom.xml
+dependency-reduced-pom.xml
 pom.xml.asc
 *.jar
 *.class

--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ Created uvl-clj/target/uvl-parser-0.1.0-SNAPSHOT-standalone.jar
 
 The `standalone.jar` includes all dependencies, while the other jar ships only the code of the uvl-parser itself, without Clojure or instaparse.
 
+Alternatively, run `mvn install` to create a JAR without Leiningen.
+
 ## Usage from Java
 The class `de.neominik.uvl.UVLParser` exposes the static method `parse(String)` which will return an instance of a `de.neominik.uvl.UVLModel` on success or a `de.neominik.uvl.ParseError` when the input didn't comply to the grammar.
 Printing is implemented in the `toString()`methods of the different model elements in the `UVLModel`.

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.spldev</groupId>
+    <artifactId>uvl-parser</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <packaging>clojure</packaging>
+
+    <name>UVL Parser</name>
+    <description>Small default parser lib for UVL</description>
+    <url>https://github.com/Universal-Variability-Language/uvl-parser</url>
+
+    <build>
+        <sourceDirectory>java</sourceDirectory>
+        <resources>
+            <resource>
+                <directory>resources</directory>
+            </resource>
+        </resources>
+        <directory>target</directory>
+        <outputDirectory>target/classes</outputDirectory>
+        <plugins>
+            <plugin>
+                <groupId>com.theoryinpractise</groupId>
+                <artifactId>clojure-maven-plugin</artifactId>
+                <version>1.8.3</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <sourceDirectories>
+                        <sourceDirectory>src</sourceDirectory>
+                    </sourceDirectories>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <execution>
+                        <id>java-compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.4</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>*:*:jar:*</include>
+                                </includes>
+                            </artifactSet>
+                            <finalName>${jar.final.name}</finalName>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <repositories>
+        <repository>
+            <id>central</id>
+            <url>https://repo1.maven.org/maven2/</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+        </repository>
+        <repository>
+            <id>clojars</id>
+            <url>https://repo.clojars.org/</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.clojure</groupId>
+            <artifactId>clojure</artifactId>
+            <version>1.10.1</version>
+        </dependency>
+        <dependency>
+            <groupId>instaparse</groupId>
+            <artifactId>instaparse</artifactId>
+            <version>1.4.10</version>
+        </dependency>
+        <dependency>
+            <groupId>com.wjoel</groupId>
+            <artifactId>clj-bean</artifactId>
+            <version>0.2.1</version>
+        </dependency>
+    </dependencies>
+</project>


### PR DESCRIPTION
As Leiningen is not available on all machines, a pure Maven build may sometimes be needed. For example, we need this to integrate UVL into the new FeatureIDE architecture, to avoid relying on a prebuilt JAR.